### PR TITLE
Update README to clarify usage of v-show

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The merged data will be:
 
 ### Vue directives
 
-Note that built-in Vue directives are not supported when using JSX. In most cases there are obvious programmatic equivalents, for example `v-if` is just a ternary expression, and `v-for` is just an `array.map()` expression, etc.
+Note that almost all built-in Vue directives are not supported when using JSX, the sole exception being `v-show`, which can be used with the `v-show={value}` syntax. In most cases there are obvious programmatic equivalents, for example `v-if` is just a ternary expression, and `v-for` is just an `array.map()` expression, etc.
 
 For custom directives, you can use the `v-name={value}` syntax. However, note that directive arguments and modifiers are not supported using this syntax. There are two workarounds:
 


### PR DESCRIPTION
Since `v-show` is the only runtime-only directive, it can be used. Otherwise there's no proper way to trigger transition with conditional display.
https://github.com/vuejs/vue/issues/4074