### PR TITLE
don't assume _mergeJSXProps is the imported name

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,10 +147,10 @@ module.exports = function (babel) {
       attribs = objs[0]
     } else if (objs.length) {
       // add prop merging helper
-      file.addImport('babel-helper-vue-jsx-merge-props', 'default', '_mergeJSXProps')
+      var helper = file.addImport('babel-helper-vue-jsx-merge-props', 'default', '_mergeJSXProps')
       // spread it
       attribs = t.callExpression(
-        t.identifier('_mergeJSXProps'),
+        helper,
         [t.arrayExpression(objs)]
       )
     }


### PR DESCRIPTION
`file.addImport()` could import under a different name if `_mergeJSXProps` isn't unique. This fix will handle that situation.

    var _mergeJSXProps = 'oops';

    const data = {
      class: ['b', 'c']
    }
    const vnode = <div class="a" {...data}/>

Before:

    import _mergeJSXProps2 from 'babel-helper-vue-jsx-merge-props';
    var _mergeJSXProps = 'oops';
    const data = {
      class: ['b', 'c']
    };
    const vnode = h(
      'div',
      _mergeJSXProps([{ 'class': 'a' }, data]),
      []
    );

After:

    import _mergeJSXProps2 from 'babel-helper-vue-jsx-merge-props';
    var _mergeJSXProps = 'oops';
    const data = {
      class: ['b', 'c']
    };
    const vnode = h(
      'div',
      _mergeJSXProps2([{ 'class': 'a' }, data]),
      []
    );

