### PR TITLE
Bugfix, in multi-level objects `h` should not be defined twice.

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,20 @@ module.exports = function (babel) {
             if (!jsxChecker.hasJsx) {
               return
             }
+            // do nothing if `h` is already defined in this method
+            const hChecker = {
+              hasH: false
+            }
+            path.traverse({
+              VariableDeclarator (path) {
+                if (path.node && path.node.id && path.node.id.name === 'h') {
+                  this.hasH = true
+                }
+              }
+            }, hChecker)
+            if (hChecker.hasH) {
+              return
+            }
             // prepend const h = this.$createElement otherwise
             path.get('body').unshiftContainer('body', t.variableDeclaration('const', [
               t.variableDeclarator(

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function (babel) {
           path.replaceWith(t.inherits(callExpr, path.node))
         }
       },
-      'ObjectExpression|ClassDeclaration' (path) {
+      'Program' (path) {
         path.traverse({
           'ObjectMethod|ClassMethod' (path) {
             const params = path.get('params')
@@ -43,20 +43,6 @@ module.exports = function (babel) {
               }
             }, jsxChecker)
             if (!jsxChecker.hasJsx) {
-              return
-            }
-            // do nothing if `h` is already defined in this method
-            const hChecker = {
-              hasH: false
-            }
-            path.traverse({
-              VariableDeclarator (path) {
-                if (path.node && path.node.id && path.node.id.name === 'h') {
-                  this.hasH = true
-                }
-              }
-            }, hChecker)
-            if (hChecker.hasH) {
               return
             }
             // prepend const h = this.$createElement otherwise

--- a/test/test.js
+++ b/test/test.js
@@ -216,6 +216,22 @@ describe('babel-plugin-transform-vue-jsx', () => {
     expect(vnode.children[0].text).to.equal('test')
   })
 
+  it('h self-defining in multi-level object getters', () => {
+    const obj = {
+      inherited: {
+        get render () {
+          return <div>test</div>
+        }
+      }
+    }
+    const vnode = render(h => {
+      obj.inherited.$createElement = h
+      return obj.inherited.render
+    })
+    expect(vnode.tag).to.equal('div')
+    expect(vnode.children[0].text).to.equal('test')
+  })
+
   it('h self-defining in class methods', () => {
     class Test {
       constructor (h) {


### PR DESCRIPTION
@yyx990803, this is kinda urgent, previous `h` auto-injection worked only on flat objects, doesn't work on inherited ones. It actually breaks the inherited objects #65.