### PR TITLE
Updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ npm install\
   babel-plugin-syntax-jsx\
   babel-plugin-transform-vue-jsx\
   babel-helper-vue-jsx-merge-props\
+  babel-preset-es2015\
   --save-dev
 ```
 


### PR DESCRIPTION
Adds `babel-preset-es2015` to "Usage" section; specifically in the dependencies installation example. Issue arose out of #40 