### PR TITLE
Remove unnecessary information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@
 
 ``` bash
 npm install\
-  babel-plugin-syntax-jsx\
   babel-plugin-transform-vue-jsx\
-  babel-helper-vue-jsx-merge-props\
   --save-dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "babel-cli": "^6.10.1",
     "babel-helper-vue-jsx-merge-props": "^2.0.2",
     "babel-loader": "^6.2.4",
-    "babel-plugin-syntax-jsx": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",
     "chai": "^3.5.0",


### PR DESCRIPTION
We have all that requirements from `README.md` covered as dependencies in `package.json` and the `devDependency` doesn't really make sense if we have a `dependency`.