### PR TITLE
fixed custom directives binding bug (fix #69).

### DIFF
--- a/lib/group-props.js
+++ b/lib/group-props.js
@@ -44,26 +44,26 @@ module.exports = function groupProps (props, t) {
           newProps.push(dirs)
         }
         var tempDirAttr = [];
-        if(/^Object.+/.test(prop.value.type)){
-          for(let item of prop.value.properties ){
+        if (/^Object.+/.test(prop.value.type)) {
+          for (let item of prop.value.properties) {
             tempDirAttr.push(t.objectProperty(
-                t.identifier(item.key.name),
-                item.value
+              t.identifier(item.key.name),
+              item.value
             ))
           }
-          } else{
-            tempDirAttr.push(t.objectProperty(
-                t.identifier('value'),
-                prop.value
-            ))
-          }
-          dirs.value.elements.push(t.objectExpression([
-            t.objectProperty(
-              t.identifier('name'),
-              t.stringLiteral(name)
-            ),
-            ...tempDirAttr
-          ]))
+        } else {
+          tempDirAttr.push(t.objectProperty(
+            t.identifier('value'),
+            prop.value
+          ))
+        }
+        dirs.value.elements.push(t.objectExpression([
+          t.objectProperty(
+            t.identifier('name'),
+            t.stringLiteral(name)
+          ),
+          ...tempDirAttr
+        ]))
       } else {
         // rest are nested under attrs
         var attrs = currentNestedObjects.attrs

--- a/lib/group-props.js
+++ b/lib/group-props.js
@@ -43,16 +43,27 @@ module.exports = function groupProps (props, t) {
           )
           newProps.push(dirs)
         }
-        dirs.value.elements.push(t.objectExpression([
-          t.objectProperty(
-            t.identifier('name'),
-            t.stringLiteral(name)
-          ),
-          t.objectProperty(
-            t.identifier('value'),
-            prop.value
-          )
-        ]))
+        var tempDirAttr = [];
+        if(/^Object.+/.test(prop.value.type)){
+          for(let item of prop.value.properties ){
+            tempDirAttr.push(t.objectProperty(
+                t.identifier(item.key.name),
+                item.value
+            ))
+          }
+          } else{
+            tempDirAttr.push(t.objectProperty(
+                t.identifier('value'),
+                prop.value
+            ))
+          }
+          dirs.value.elements.push(t.objectExpression([
+            t.objectProperty(
+              t.identifier('name'),
+              t.stringLiteral(name)
+            ),
+            ...tempDirAttr
+          ]))
       } else {
         // rest are nested under attrs
         var attrs = currentNestedObjects.attrs


### PR DESCRIPTION
Issue [#69](https://github.com/vuejs/babel-plugin-transform-vue-jsx/issues/69) mentioned that when 
```
v-clickoutside={{ expression: 'dismiss' }}
```
the value of a custom directive is an object, the entire object would be delegated to the `binding.value` instead of the `binding` object. I fixed it that when the value is an object the attributes inside can be correctly assigned to the `binding` object; otherwise, assigning it to the `binding.value`.