### PR TITLE
Add underscore to allowed event names first character

### DIFF
--- a/lib/group-props.js
+++ b/lib/group-props.js
@@ -1,7 +1,7 @@
 var makeMap = require('./make-map')
 var isTopLevel = makeMap('class,staticClass,style,key,ref,refInFor,slot,scopedSlots')
 var isNestable = makeMap('domProps,on,nativeOn,hook')
-var nestableRE = /^(domProps|on|nativeOn|hook)([\-A-Z])/
+var nestableRE = /^(domProps|on|nativeOn|hook)([\-_A-Z])/
 var dirRE = /^v-/
 var xlinkRE = /^xlink([A-Z])/
 


### PR DESCRIPTION
In order to build `v-model` transform for checkboxes and radio I need to use `on__c` event ([declared here](https://github.com/vuejs/vue/blob/dev/src/platforms/web/compiler/directives/model.js#L12)) so can it be considered to allow underscore as first character in event names in JSX too?