### PR TITLE
Check if node has children before adding `children` arg

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,10 @@ module.exports = function (babel) {
         exit (path, file) {
           // turn tag into createElement call
           var callExpr = buildElementCall(path.get('openingElement'), file)
-          // add children array as 3rd arg
-          callExpr.arguments.push(t.arrayExpression(path.node.children))
+          // add children array as 3rd 
+          if (path.node.children.length > 0) {
+            callExpr.arguments.push(t.arrayExpression(path.node.children))
+          }
           if (callExpr.arguments.length >= 3) {
             callExpr._prettyCall = true
           }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (babel) {
         exit (path, file) {
           // turn tag into createElement call
           var callExpr = buildElementCall(path.get('openingElement'), file)
-          // add children array as 3rd 
+          // add children array as 3rd arg
           if (path.node.children.length > 0) {
             callExpr.arguments.push(t.arrayExpression(path.node.children))
           }


### PR DESCRIPTION
Before:
`<Foo/>` => `h(Foo, null, [])`

After:
`<Foo/>` => `h(Foo, null)`

Should give slightly better runtime performance.