### PR TITLE
Omit attribs if possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,10 +18,12 @@ module.exports = function (babel) {
         exit (path, file) {
           // turn tag into createElement call
           var callExpr = buildElementCall(path.get('openingElement'), file)
-          // add children array as 3rd arg
-          callExpr.arguments.push(t.arrayExpression(path.node.children))
-          if (callExpr.arguments.length >= 3) {
-            callExpr._prettyCall = true
+          if (path.node.children.length) {
+            // add children array as 3rd arg
+            callExpr.arguments.push(t.arrayExpression(path.node.children))
+            if (callExpr.arguments.length >= 3) {
+              callExpr._prettyCall = true
+            }
           }
           path.replaceWith(t.inherits(callExpr, path.node))
         }

--- a/index.js
+++ b/index.js
@@ -114,11 +114,8 @@ module.exports = function (babel) {
     var attribs = path.node.attributes
     if (attribs.length) {
       attribs = buildOpeningElementAttributes(attribs, file)
-    } else {
-      attribs = t.nullLiteral()
+      args.push(attribs)
     }
-    args.push(attribs)
-
     return t.callExpression(t.identifier('h'), args)
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+/* eslint-env node, mocha */
 import { expect } from 'chai'
 import Vue from 'vue'
 
@@ -25,6 +26,11 @@ describe('babel-plugin-transform-vue-jsx', () => {
     const id = 'foo'
     const vnode = render(h => <div id={id}></div>)
     expect(vnode.data.attrs.id).to.equal('foo')
+  })
+
+  it('should omit attribs if possible', () => {
+    const vnode = render(h => <div>test</div>)
+    expect(vnode.data).to.equal(undefined)
   })
 
   it('should omit children argument if possible', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -27,6 +27,12 @@ describe('babel-plugin-transform-vue-jsx', () => {
     expect(vnode.data.attrs.id).to.equal('foo')
   })
 
+  it('should omit children argument if possible', () => {
+    const vnode = render(h => <div />)
+    const children = vnode.children
+    expect(children).to.equal(undefined)
+  })
+
   it('should handle top-level special attrs', () => {
     const vnode = render(h => (
       <div


### PR DESCRIPTION
Before:
`<div>123</div>` => `h('div', null, ['123'])`

After:
`<div>123</div>` => `h('div', ['123'])`

Should slight improve bundle size and runtime performance.
And this makes JSX transform plugin behave more like template compiler, which should prevents JSX users to run into some corner cases.