### PR TITLE
Change readme example props to kebab-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,17 +141,17 @@ render (h) {
       // normal attributes or component props.
       id="foo"
       // DOM properties are prefixed with `domProps`
-      domPropsInnerHTML="bar"
+      dom-props-inner-hTML="bar"
       // event listeners are prefixed with `on` or `nativeOn`
-      onClick={this.clickHandler}
-      nativeOnClick={this.nativeClickHandler}
+      on-click={this.clickHandler}
+      native-on-click={this.nativeClickHandler}
       // other special top-level properties
       class={{ foo: true, bar: false }}
       style={{ color: 'red', fontSize: '14px' }}
       key="key"
       ref="ref"
       // assign the `ref` is used on elements/components with v-for
-      refInFor
+      ref-in-for
       slot="slot">
     </div>
   )


### PR DESCRIPTION
In readme example, JSX property is camelCase.

But in Vue.js style-guide recommend kebab-case properties.

https://vuejs.org/v2/style-guide/#Prop-name-casing-strongly-recommended

> Prop names should always use camelCase during declaration, but kebab-case in templates and JSX.
