### PR TITLE
add support for `on-event` props (fix #110)

### DIFF
--- a/lib/group-props.js
+++ b/lib/group-props.js
@@ -1,7 +1,6 @@
 var makeMap = require('./make-map')
 var isTopLevel = makeMap('class,staticClass,style,key,ref,refInFor,slot,scopedSlots')
-var isNestable = makeMap('domProps,on,nativeOn,hook')
-var nestableRE = /^(domProps|on|nativeOn|hook)([\-_A-Z])/
+var nestableRE = /^(props|domProps|on|nativeOn|hook)([\-_A-Z])/
 var dirRE = /^v-/
 var xlinkRE = /^xlink([A-Z])/
 

--- a/test/test.js
+++ b/test/test.js
@@ -56,12 +56,14 @@ describe('babel-plugin-transform-vue-jsx', () => {
     const noop = _ => _
     const vnode = render(h => (
       <div
+        props-on-success={noop}
         on-click={noop}
         on-kebab-case={noop}
         domProps-innerHTML="<p>hi</p>"
         hook-insert={noop}>
       </div>
     ))
+    expect(vnode.data.props['on-success']).to.equal(noop)
     expect(vnode.data.on.click).to.equal(noop)
     expect(vnode.data.on['kebab-case']).to.equal(noop)
     expect(vnode.data.domProps.innerHTML).to.equal('<p>hi</p>')
@@ -72,12 +74,14 @@ describe('babel-plugin-transform-vue-jsx', () => {
     const noop = _ => _
     const vnode = render(h => (
       <div
+        propsOnSuccess={noop}
         onClick={noop}
         onCamelCase={noop}
         domPropsInnerHTML="<p>hi</p>"
         hookInsert={noop}>
       </div>
     ))
+    expect(vnode.data.props.onSuccess).to.equal(noop)
     expect(vnode.data.on.click).to.equal(noop)
     expect(vnode.data.on.camelCase).to.equal(noop)
     expect(vnode.data.domProps.innerHTML).to.equal('<p>hi</p>')


### PR DESCRIPTION
usage: 
```
render (h) {
  return h('third-party-component', {
    props: {
      onSuccess: this.handleSuccess
    }
  })
}
```
->
```
render (h) {
  return (
    <third-party-component propsOnSuccess={this.handleSuccess} />
  )
}
```
