### PR TITLE
chore: add babel-plugin-syntax-jsx as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "esutils": "^2.0.2"
   },
   "peerDependencies": {
-    "babel-helper-vue-jsx-merge-props": "^2.0.0"
+    "babel-helper-vue-jsx-merge-props": "^2.0.0",
+    "babel-plugin-syntax-jsx": "^6.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Required for pnpm compatibility.