### PR TITLE
Update babel-present-env to @babel/preset-env in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In your `.babelrc`:
 
 ``` json
 {
-  "presets": ["env"],
+  "presets": ["@babel/env"],
   "plugins": ["transform-vue-jsx"]
 }
 ```


### PR DESCRIPTION
The preset `babel-preset-env` was [moved into the main babel monorepo](https://github.com/babel/babel-preset-env). As a result, the preset has been changed from `babel-present-env` to `@babel/preset-env`.